### PR TITLE
[TASK] Specify extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,4 +31,9 @@
       "Pixelant\\PxaLpeh\\": "Classes/"
     }
   }
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "pxa_lpeh"
+    }
+  }
 }


### PR DESCRIPTION
Specifying the extension key will be mandatory in future versions of TYPO3.

See:
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra